### PR TITLE
Pretty printer

### DIFF
--- a/Instructions.hs
+++ b/Instructions.hs
@@ -1,3 +1,5 @@
+module Instructions where
+
 import Data.Word (Word16, Word32, Word8)
 
 {-
@@ -76,7 +78,7 @@ data Instruction
   | WDM Operand
   | PEA Operand
   | PEI Operand
-  | PER
+  | PER Operand
   | PHA
   | PHX
   | PHY
@@ -149,6 +151,122 @@ data Operand
   | Label24 String -- location defined
   deriving (Show)
 
+-- "common" operands are for the set of  arithmetic/memory instructions
+-- which all accept a lot (15) of operand types
+isCommonOp :: Operand -> Bool
+isCommonOp (DirXInd _) = True
+isCommonOp (Stack _) = True
+isCommonOp (Dir _) = True
+isCommonOp (DirIndLong _) = True
+isCommonOp (Imm8 _) = True
+isCommonOp (Imm16 _) = True
+isCommonOp (Abs _) = True
+isCommonOp (Long _) = True
+isCommonOp (DirIndY _) = True
+isCommonOp (DirInd _) = True
+isCommonOp (StackIndY _) = True
+isCommonOp (DirX _) = True
+isCommonOp (DirIndLongY _) = True
+isCommonOp (AbsY _) = True
+isCommonOp (AbsX _) = True
+isCommonOp (LongX _) = True
+isCommonOp _ = False
+
+-- operand types for CPX and CPY
+isCompareOp :: Operand -> Bool
+isCompareOp (Imm8 _) = True
+isCompareOp (Imm16 _) = True
+isCompareOp (Dir _) = True
+isCompareOp (Abs _) = True
+isCompareOp _ = False
+
+-- operand types for INC, DEC, ASL, LSR, ROL, ROR
+isShiftOp :: Operand -> Bool
+isShiftOp Accumulator = True
+isShiftOp (Dir _) = True
+isShiftOp (Abs _) = True
+isShiftOp (DirX _) = True
+isShiftOp (AbsX _) = True
+isShiftOp _ = False
+
+-- operand types for BIT
+isBitOp :: Operand -> Bool
+isBitOp (Dir _) = True
+isBitOp (Abs _) = True
+isBitOp (DirX _) = True
+isBitOp (AbsX _) = True
+isBitOp (Imm8 _) = True
+isBitOp (Imm16 _) = True
+isBitOp _ = False
+
+-- operand types for TRB and TSB
+isTestOp :: Operand -> Bool
+isTestOp (Dir _) = True
+isTestOp (Abs _) = True
+isTestOp _ = False
+
+-- operand types for BCC, BCS, BEQ, BMI, BNE, BPL, BRA, BVC, BVS
+isBranchOp :: Operand -> Bool
+isBranchOp (Label8 _) = True
+isBranchOp _ = False
+
+-- operand types for JMP
+isJumpOp :: Operand -> Bool
+isJumpOp (Label16 _) = True
+isJumpOp (Label24 _) = True
+isJumpOp (AbsInd _) = True -- but these can be labels!
+isJumpOp (AbsXInd _) = True -- but these can be labels!
+isJumpOp (AbsIndLong _) = True -- but these can be labels!
+isJumpOp _ = False
+
+-- operand types for JSR
+isJsrOp :: Operand -> Bool
+isJsrOp (Label16 _) = True
+isJsrOp (AbsXInd _) = True -- but these can be labels!
+isJsrOp _ = False
+
+-- operand types for LDX
+isLoadXOp :: Operand -> Bool
+isLoadXOp (Imm8 _) = True
+isLoadXOp (Imm16 _) = True
+isLoadXOp (Abs _) = True
+isLoadXOp (AbsY _) = True
+isLoadXOp (Dir _) = True
+isLoadXOp (DirY _) = True
+isLoadXOp _ = False
+
+-- operand types for LDY
+isLoadYOp :: Operand -> Bool
+isLoadYOp (Imm8 _) = True
+isLoadYOp (Imm16 _) = True
+isLoadYOp (Abs _) = True
+isLoadYOp (AbsX _) = True
+isLoadYOp (Dir _) = True
+isLoadYOp (DirX _) = True
+isLoadYOp _ = False
+
+-- operand types for STX
+isStoreXOp :: Operand -> Bool
+isStoreXOp (Abs _) = True
+isStoreXOp (Dir _) = True
+isStoreXOp (DirY _) = True
+isStoreXOp _ = False
+
+-- operand types for STY
+isStoreYOp :: Operand -> Bool
+isStoreYOp (Abs _) = True
+isStoreYOp (Dir _) = True
+isStoreYOp (DirX _) = True
+isStoreYOp _ = False
+
+-- operand types for STZ
+isStoreZOp :: Operand -> Bool
+isStoreZOp (Abs _) = True
+isStoreZOp (AbsX _) = True
+isStoreZOp (Dir _) = True
+isStoreZOp (DirX _) = True
+isStoreZOp _ = False
+
 isValidOperand :: Instruction -> Bool
 isValidOperand (ADC operand) = isCommonOp operand
 isValidOperand (SBC operand) = isCommonOp operand
@@ -198,97 +316,6 @@ isValidOperand (WDM (Imm8 _)) = True -- only valid operand type
 isValidOperand (PEA (Imm16 _)) = True -- only valid operand type
 isValidOperand (PEI (Dir _)) = True -- only valid operand type
 isValidOperand (PER (Label16 _)) = True -- only valid operand type
-  where
-    -- "common" operands are for the set of  arithmetic/memory instructions
-    -- which all accept a lot (15) of operand types
-    isCommonOp (DirXInd _) = True
-    isCommonOp (Stack _) = True
-    isCommonOp (Dir _) = True
-    isCommonOp (DirIndLong _) = True
-    isCommonOp (Imm8 _) = True
-    isCommonOp (Imm16 _) = True
-    isCommonOp (Abs _) = True
-    isCommonOp (Long _) = True
-    isCommonOp (DirIndY _) = True
-    isCommonOp (DirInd _) = True
-    isCommonOp (StackIndY _) = True
-    isCommonOp (DirX _) = True
-    isCommonOp (DirIndLongY _) = True
-    isCommonOp (AbsY _) = True
-    isCommonOp (AbsX _) = True
-    isCommonOp (LongX _) = True
-    isCommonOp _ = False
-    -- operand types for CPX and CPY
-    isCompareOp (Imm8 _) = True
-    isCompareOp (Imm16 _) = True
-    isCompareOp (Dir _) = True
-    isCompareOp (Abs _) = True
-    isCompareOp _ = False
-    -- operand types for INC, DEC, ASL, LSR, ROL, ROR
-    isShiftOp Accumulator = True
-    isShiftOp (Dir _) = True
-    isShiftOp (Abs _) = True
-    isShiftOp (DirX _) = True
-    isShiftOp (AbsX _) = True
-    isShiftOp _ = False
-    -- operand types for BIT
-    isBitOp (Dir _) = True
-    isBitOp (Abs _) = True
-    isBitOp (DirX _) = True
-    isBitOp (AbsX _) = True
-    isBitOp (Imm8 _) = True
-    isBitOp (Imm16 _) = True
-    isBitOp _ = False
-    -- operand types for TRB and TSB
-    isTestOp (Dir _) = True
-    isTestOp (Abs _) = True
-    isTestOp _ = False
-    -- operand types for BCC, BCS, BEQ, BMI, BNE, BPL, BRA, BVC, BVS
-    isBranchOp (Label8 _) = True
-    isBranchOp _ = False
-    -- operand types for JMP
-    isJumpOp (Label16 _) = True
-    isJumpOp (Label24 _) = True
-    isJumpOp (AbsInd _) = True -- but these can be labels!
-    isJumpOp (AbsXInd _) = True -- but these can be labels!
-    isJumpOp (AbsIndLong _) = True -- but these can be labels!
-    isJumpOp _ = False
-    -- operand types for JSR
-    isJsrOp (Label16 _) = True
-    isJsrOp (AbsXInd _) = True -- but these can be labels!
-    isJsrOp _ = False
-    -- operand types for LDX
-    isLoadXOp (Imm8 _) = True
-    isLoadXOp (Imm16 _) = True
-    isLoadXOp (Abs _) = True
-    isLoadXOp (AbsY _) = True
-    isLoadXOp (Dir _) = True
-    isLoadXOp (DirY _) = True
-    isLoadXOp _ = False
-    -- operand types for LDY
-    isLoadYOp (Imm8 _) = True
-    isLoadYOp (Imm16 _) = True
-    isLoadYOp (Abs _) = True
-    isLoadYOp (AbsX _) = True
-    isLoadYOp (Dir _) = True
-    isLoadYOp (DirX _) = True
-    isLoadYOp _ = False
-    -- operand types for STX
-    isStoreXOp (Abs _) = True
-    isStoreXOp (Dir _) = True
-    isStoreXOp (DirY _) = True
-    isStoreXOp _ = False
-    -- operand types for STY
-    isStoreYOp (Abs _) = True
-    isStoreYOp (Dir _) = True
-    isStoreYOp (DirX _) = True
-    isStoreYOp _ = False
-    -- operand types for STZ
-    isStoreZOp (Abs _) = True
-    isStoreZOp (Absx _) = True
-    isStoreZOp (Dir _) = True
-    isStoreZOp (DirX _) = True
-    isStoreZOp _ = False
 isValidOperand _ = False -- everything else is false
 {-
 Addressing addressing modes:

--- a/Pretty65816.hs
+++ b/Pretty65816.hs
@@ -1,0 +1,131 @@
+import Prettyprinter
+import Prettyprinter.Render.Text
+import System.IO
+
+import Instructions
+
+instance Pretty Instruction where
+  pretty (ADC o) = indent 4 (group (pretty "ADC" <> pretty o))
+  pretty (SBC o) = indent 4 (group (pretty "SBC" <> pretty o))
+  pretty (CMP o) = indent 4 (group (pretty "CMP" <> pretty o))
+  pretty (CPX o) = indent 4 (group (pretty "CPX" <> pretty o))
+  pretty (CPY o) = indent 4 (group (pretty "CPY" <> pretty o))
+  pretty (DEC o) = indent 4 (group (pretty "DEC" <> pretty o))
+  pretty (DEX) = indent 4 (pretty "DEX")
+  pretty (DEY) = pretty "DEY"
+  pretty (INC o) = indent 4 (group (pretty "INC" <> pretty o))
+  pretty (INX) = indent 4 (pretty "INX")
+  pretty (INY) = indent 4 (pretty "INY")
+  pretty (AND o) = indent 4 (group (pretty "AND" <> pretty o))
+  pretty (EOR o) = indent 4 (group (pretty "EOR" <> pretty o))
+  pretty (ORA o) = indent 4 (group (pretty "ORA" <> pretty o))
+  pretty (BIT o) = indent 4 (group (pretty "BIT" <> pretty o))
+  pretty (TRB o) = indent 4 (group (pretty "TRB" <> pretty o))
+  pretty (TSB o) = indent 4 (group (pretty "TSB" <> pretty o))
+  pretty (ASL o) = indent 4 (group (pretty "ASL" <> pretty o))
+  pretty (LSR o) = indent 4 (group (pretty "LSR" <> pretty o))
+  pretty (ROL o) = indent 4 (group (pretty "ROL" <> pretty o))
+  pretty (ROR o) = indent 4 (group (pretty "ROR" <> pretty o))
+  pretty (BCC o) = indent 4 (group (pretty "BCC" <> pretty o))
+  pretty (BCS o) = indent 4 (group (pretty "BCS" <> pretty o))
+  pretty (BEQ o) = indent 4 (group (pretty "BEQ" <> pretty o))
+  pretty (BMI o) = indent 4 (group (pretty "BMI" <> pretty o))
+  pretty (BNE o) = indent 4 (group (pretty "BNE" <> pretty o))
+  pretty (BPL o) = indent 4 (group (pretty "BPL" <> pretty o))
+  pretty (BRA o) = indent 4 (group (pretty "BRA" <> pretty o))
+  pretty (BVC o) = indent 4 (group (pretty "BVC" <> pretty o))
+  pretty (BVS o) = indent 4 (group (pretty "BVS" <> pretty o))
+  pretty (BRL o) = indent 4 (group (pretty "BRL" <> pretty o))
+  pretty (JMP o) = indent 4 (group (pretty "JMP" <> pretty o))
+  pretty (JSL o) = indent 4 (group (pretty "JSL" <> pretty o))
+  pretty (JSR o) = indent 4 (group (pretty "JSR" <> pretty o))
+  pretty (RTL) = indent 4 (pretty "RTL")
+  pretty (RTS) = indent 4 (pretty "RTS")
+  pretty (BRK o) = indent 4 (group (pretty "BRK" <> pretty o))
+  pretty (COP o) = indent 4 (group (pretty "COP" <> pretty o))
+  pretty (RTI) = indent 4 (pretty "RTI")
+  pretty (CLC) = indent 4 (pretty "CLC")
+  pretty (CLD) = indent 4 (pretty "CLD")
+  pretty (CLI) = indent 4 (pretty "CLI")
+  pretty (CLV) = indent 4 (pretty "CLV")
+  pretty (SEC) = indent 4 (pretty "SEC")
+  pretty (SED) = indent 4 (pretty "SED")
+  pretty (SEI) = indent 4 (pretty "SEI")
+  pretty (REP o) = indent 4 (group (pretty "REP" <> pretty o))
+  pretty (SEP o) = indent 4 (group (pretty "SEP" <> pretty o))
+  pretty (LDA o) = indent 4 (group (pretty "LDA" <> pretty o))
+  pretty (LDX o) = indent 4 (group (pretty "LDX" <> pretty o))
+  pretty (LDY o) = indent 4 (group (pretty "LDY" <> pretty o))
+  pretty (STA o) = indent 4 (group (pretty "STA" <> pretty o))
+  pretty (STX o) = indent 4 (group (pretty "STX" <> pretty o))
+  pretty (STY o) = indent 4 (group (pretty "STY" <> pretty o))
+  pretty (STZ o) = indent 4 (group (pretty "STZ" <> pretty o))
+  pretty (MVN (Imm8 i1) (Imm8 i2)) =
+    indent 4 (group (pretty "MVN" <> pretty i1 <> pretty "," <> pretty i2))
+  pretty (MVP (Imm8 i1) (Imm8 i2)) =
+    indent 4 (group (pretty "MVP" <> pretty i1 <> pretty "," <> pretty i2))
+  pretty (NOP) = indent 4 (pretty "NOP")
+  pretty (WDM o) = indent 4 (group (pretty "WDM" <> pretty o))
+  pretty (PEA o) = indent 4 (group (pretty "PEA" <> pretty o))
+  pretty (PEI o) = indent 4 (group (pretty "PEI" <> pretty o))
+  pretty (PER o) = indent 4 (group (pretty "PER" <> pretty o))
+  pretty (PHA) = indent 4 (pretty "PHA")
+  pretty (PHX) = indent 4 (pretty "PHX")
+  pretty (PHY) = indent 4 (pretty "PHY")
+  pretty (PLA) = indent 4 (pretty "PLA")
+  pretty (PLX) = indent 4 (pretty "PLX")
+  pretty (PLY) = indent 4 (pretty "PLY")
+  pretty (PHB) = indent 4 (pretty "PHB")
+  pretty (PHD) = indent 4 (pretty "PHD")
+  pretty (PHK) = indent 4 (pretty "PHK")
+  pretty (PHP) = indent 4 (pretty "PHP")
+  pretty (PLB) = indent 4 (pretty "PLB")
+  pretty (PLD) = indent 4 (pretty "PLD")
+  pretty (PLP) = indent 4 (pretty "PLP")
+  pretty (STP) = indent 4 (pretty "STP")
+  pretty (WAI) = indent 4 (pretty "WAI")
+  pretty (TAX) = indent 4 (pretty "TAX")
+  pretty (TAY) = indent 4 (pretty "TAY")
+  pretty (TSX) = indent 4 (pretty "TSX")
+  pretty (TXA) = indent 4 (pretty "TXA")
+  pretty (TXS) = indent 4 (pretty "TXS")
+  pretty (TXY) = indent 4 (pretty "TXY")
+  pretty (TYA) = indent 4 (pretty "TYA")
+  pretty (TYX) = indent 4 (pretty "TYX")
+  pretty (TCD) = indent 4 (pretty "TCD")
+  pretty (TCS) = indent 4 (pretty "TCS")
+  pretty (TDC) = indent 4 (pretty "TDC")
+  pretty (TSC) = indent 4 (pretty "TSC")
+  pretty (XBA) = indent 4 (pretty "XBA")
+  pretty (XCE) = indent 4 (pretty "XCE")
+  pretty (Label s) = group (pretty s <> pretty ":")
+
+instance Pretty Operand where
+  pretty (Imm8 w) = pretty ".B" <+> pretty "#" <> pretty w
+  pretty (Imm16 w) = pretty ".W" <+> pretty "#" <> pretty w
+  pretty (Abs w) = pretty ".W" <+> pretty w
+  pretty (AbsX w) = pretty ".W" <+> pretty w <> pretty ",X"
+  pretty (AbsY w) = pretty ".W" <+> pretty w <> pretty ",Y"
+  pretty (Dir w) = pretty ".B" <+> pretty w
+  pretty (DirX w) = pretty ".B" <+> pretty w <> pretty ",X"
+  pretty (DirY w) = pretty ".B" <+> pretty w <> pretty ",Y"
+  pretty (Accumulator) = pretty "A"
+  pretty (DirInd w) = pretty ".B" <+> parens (pretty w)
+  pretty (Long w) = pretty ".L" <+> pretty w
+  pretty (LongX w) = pretty ".L" <+> pretty w <> pretty ",X"
+  pretty (DirIndLong w) = pretty ".B" <+> brackets (pretty w)
+  pretty (DirIndY w) = pretty ".B" <+> parens (pretty w) <> pretty ",Y"
+  pretty (DirXInd w) = pretty ".B" <+> parens (pretty w <> pretty ",X")
+  pretty (AbsInd w) = pretty ".W" <+> parens (pretty w)
+  pretty (AbsIndLong w) = pretty ".W" <+> brackets (pretty w)
+  pretty (AbsXInd w) = pretty ".W" <+> parens (pretty w <> pretty ",X")
+  pretty (DirIndLongY w) = pretty ".B" <+> brackets (pretty w) <> pretty ",Y"
+  pretty (Stack w) = pretty ".B" <+> pretty w <> pretty ",S"
+  pretty (StackIndY w) =
+    pretty ".B" <+> parens (pretty w <> pretty ",S") <> pretty ",Y"
+  pretty (Label8 s) = pretty ".B" <+> pretty s
+  pretty (Label16 s) = pretty ".W" <+> pretty s
+  pretty (Label24 s) = pretty ".L" <+> pretty s
+
+putDocCompact :: Doc a -> IO ()
+putDocCompact = renderIO System.IO.stdout . layoutCompact

--- a/PrettyASM.hs
+++ b/PrettyASM.hs
@@ -1,0 +1,56 @@
+import Prettyprinter
+import Prettyprinter.Render.Text
+import System.IO
+
+{-
+  This is a test implementation for pretty printing with a simple fake
+  assembly.
+-}
+-- dummy types
+data Program =
+  Code [Instr]
+
+data Instr
+  = Add Operand
+  | Sub Operand
+  | Label String
+  deriving (Show)
+
+data Operand
+  = One Integer
+  | Two String
+  deriving (Show)
+
+instance Pretty Program where
+  pretty (Code is) = vsep (map pretty is)
+
+instance Pretty Instr where
+  pretty (Add o) = indent 4 (group (pretty "Add" <+> pretty o))
+  {- is this the right place for indent? assembly programs don't really lend
+     themselves to the kind of "block" layout which I think pretty printers are
+     really effective towards. Labels, which don't get indentation, don't
+     necessarily own the code under it (unless we try to enforce nested
+     labels, which asar supports).
+   -}
+  pretty (Sub o) = indent 4 (group (pretty "Sub" <+> pretty o))
+  pretty (Label s) = group (pretty s <> pretty ":")
+
+instance Pretty Operand where
+  pretty (One x) = pretty x
+  pretty (Two s) = pretty s
+
+exampleCode :: Program
+exampleCode =
+  Code
+    [ Add (One 50)
+    , Sub (One 25)
+    , Label "foo"
+    , Sub (Two "foo")
+    , Label "bar"
+    , Add (One 10)
+    , Sub (One 20)
+    , Add (Two "bar")
+    ]
+
+putDocCompact :: Doc a -> IO ()
+putDocCompact = renderIO System.IO.stdout . layoutCompact

--- a/PrettyPrint.hs
+++ b/PrettyPrint.hs
@@ -1,0 +1,150 @@
+data Doc -- the constructors are not public to the user
+  = Nil
+  | Text String Doc
+  | Line Int Doc
+  | Union Doc Doc
+
+-- monoid?
+(<>) :: Doc -> Doc -> Doc
+(<>) doc y =
+  case doc of
+    Text s x -> Text s (x Main.<> y) -- x is a Doc
+    Line i x -> Line i (x Main.<> y)
+    Nil -> y
+    Union x z -> Union (x Main.<> y) (z Main.<> y)
+
+-- these functions are the API (?) which makes the implementation opaque
+nil :: Doc
+nil = Nil
+
+text :: String -> Doc
+text s = Text s Nil -- simple conversion
+
+line :: Doc
+line = Line 0 Nil -- 0 nesting?
+
+nest :: Int -> Doc -> Doc
+nest i doc =
+  case doc of
+    Text s x -> Text s (nest i x)
+    Line j x -> Line (i + j) (nest i x)
+    Nil -> Nil
+    Union x y -> Union (nest i x) (nest i y)
+
+layout :: Doc -> String
+layout doc =
+  case doc of
+    Text s x -> s ++ layout x
+    Line i x -> '\n' : replicate i ' ' ++ layout x
+    Nil -> ""
+
+{-
+Given a document, representing a set of layouts, group returns the set with one
+new element added, representing the layout in which everything is compressed
+on one line.
+-}
+group :: Doc -> Doc
+group doc =
+  case doc of
+    Text s x -> Text s (group x)
+    Line i x -> Union (Text " " (flatten x)) (Line i x) -- two options here
+    Nil -> Nil
+    Union x y -> Union (group x) y -- left only? an invariant I don't understand
+
+-- w total width
+pretty :: Int -> Doc -> String
+pretty w doc = layout (best w 0 doc) -- 0 = no chars on first line
+
+(<|>) :: Doc -> Doc -> Doc -- union of two sets of layouts
+(<|>) x y = Union x y
+
+flatten :: Doc -> Doc
+flatten doc =
+  case doc of
+    Text s x -> Text s (flatten x)
+    Line i x -> Text " " (flatten x) -- same as above except no union?
+    Nil -> Nil
+    Union x y -> flatten x -- also due to the invariant
+
+{-
+Next, it is necessary to choose the best among the set of possible layouts. This
+is done with a function best, which takes a document that may contain unions, and
+returns a document containing no unions.
+
+params:
+- the available width w
+- the number of characters k already placed on the current line
+-}
+best :: Int -> Int -> Doc -> Doc
+best w k doc =
+  case doc of
+    Nil -> Nil
+    -- for a newline it is set to the indentation
+    Line i x -> Line i (best w i x)
+    -- for text it is incremented by the string length
+    Text s x -> Text s (best w (k + length s) x)
+    -- For a union, the better of the best of the two options is selected
+    Union x y -> better w k (best w k x) (best w k y)
+
+better :: Int -> Int -> Doc -> Doc -> Doc
+better w k x y =
+  if fits (w - k) x
+    then x
+    else y
+
+fits :: Int -> Doc -> Bool
+fits w doc =
+  if w < 0 -- no available width remaining for anything else
+    then False
+    else case doc of
+           Nil -> True
+           -- if the document begins with text then it fits if the remaining
+           -- document fits in the remaining space
+           Text s x -> fits (w - length s) x
+           Line i x -> True -- always true?... document begins with newline!
+
+{-
+TREE EXAMPLE!!
+-}
+data Tree =
+  Node String [Tree]
+
+showTree :: Tree -> Doc
+showTree (Node s ts) = text s Main.<> nest (length s) (showBracket ts)
+
+showBracket :: [Tree] -> Doc
+showBracket [] = nil
+showBracket ts = text "[" Main.<> nest 1 (showTrees ts) Main.<> text "]"
+
+showTrees :: [Tree] -> Doc
+showTrees [t] = showTree t
+showTrees (t:ts) = showTree t Main.<> text "," Main.<> line Main.<> showTrees ts
+
+showTree' :: Tree -> Doc
+showTree' (Node s ts) = text s Main.<> showBracket' ts
+
+showBracket' :: [Tree] -> Doc
+showBracket' [] = nil
+showBracket' ts =
+  text "[" Main.<> nest 2 (line Main.<> showTrees' ts) Main.<> line Main.<>
+  text "]"
+
+showTrees' :: [Tree] -> Doc
+showTrees' [t] = showTree t
+showTrees' (t:ts) =
+  showTree t Main.<> text "," Main.<> line Main.<> showTrees ts
+
+tree :: Tree
+tree =
+  Node
+    "aaa"
+    [ Node "bbbbb" [Node "ccc" [], Node "dd" []]
+    , Node "eee" []
+    , Node "ffff" [Node "gg" [], Node "hhh" [], Node "ii" []]
+    ]
+
+testTree :: Int -> IO ()
+testTree w = putStrLn (pretty w (showTree tree))
+
+testTree' :: Int -> IO ()
+testTree' w = putStrLn (pretty w (showTree' tree))


### PR DESCRIPTION
In `PrettyPrint.hs` I attempt to reproduce Wadler's papers, particularly sections 1 and 2.

In `PrettyASM.hs` I made a data type for a very simplified assembly language and worked through using the `prettyprinter` package in order to define the pretty printer for it.

Finally in `Pretty65816.hs` I implement the pretty printer for the full-blown 65816.
I am a little confused on the use of the pretty printer--it seems the best examples for pretty printing are in cases of word wrap and when the document has some inherent nested structure. We don't really have this in assembly (unless there's something bigger we're planning to do). The structure is really flat and I'm not sure that I did the indentation part well